### PR TITLE
update argparse.py to version 1.1

### DIFF
--- a/lib/cli/_ext/argparse.py
+++ b/lib/cli/_ext/argparse.py
@@ -1582,7 +1582,10 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
         # add help and version arguments if necessary
         # (using explicit default to override global argument_default)
-        default_prefix = '-' if '-' in prefix_chars else prefix_chars[0]
+        if '-' in prefix_chars:        
+            default_prefix = '-'
+        else:
+            default_prefix = prefix_chars[0]
         if self.add_help:
             self.add_argument(
                 default_prefix+'h', default_prefix*2+'help',


### PR DESCRIPTION
Unfortunately, the argparse 1.0.1 distributed with pyCLI does not support the "version" keyword argument to "_VersionAction".  

This breaks pyCLI during the "setup()" call and prints a backtrace on Python 2.6 (and, likely, any other Python install that lacks argparse 1.1.

This commit updates the argparse.py sources to version 1.1.

Only tested with Python 2.6; I have not (yet) tried it with 2.5 and 2.4.
