### PR TITLE
Fixed error in FunctionalTest.setUp which caused assertEqual to fail when comparing strs

### DIFF
--- a/lib/cli/test.py
+++ b/lib/cli/test.py
@@ -206,7 +206,7 @@ class FunctionalTest(unittest.TestCase):
 
         addTypeEqualityFunc = getattr(self, "addTypeEqualityFunc", None)
         if callable(addTypeEqualityFunc):
-            addTypeEqualityFunc(str, "assertMultiLineEqual")
+            addTypeEqualityFunc(str, self.assertMultiLineEqual)
 
     def tearDown(self):
         """Clean up after the test.


### PR DESCRIPTION
The setUp method on FunctionalTest was adding a type equality function
for str. Instead of returning a reference to the TestCase.assertMultiLineEqual
method it was returning the string 'assertMultiLineEqual'. This caused
any test that used self.assertEqual(str, str) to throw an exception
as the string was not callable.
