### PR TITLE
Fixed RuntimeError in the base class

### DIFF
--- a/lib/cli/app.py
+++ b/lib/cli/app.py
@@ -211,7 +211,7 @@ class Application(object):
             returned = returned.status
         elif isinstance(returned, self.reraise):
             # raising the last exception preserves traceback
-            raise
+            raise returned
         else:
             try:
                 returned = int(returned)


### PR DESCRIPTION
This is probably a python3 specific bug, but when a decorated function (`@cli.log.LoggingApp` in this case) raises an exception it can't be raised by the base cli class and produces the following stacktrack
```Traceback (most recent call last):
  File ".\main.py", line 129, in <module>
    cli.run()
  File "~\lib\site-packages\cli\app.py", line 245, in run
    return self.post_run(returned)
  File "~\lib\site-packages\cli\app.py", line 214, in post_run
    raise
RuntimeError: No active exception to reraise```