### PR TITLE
Fix problem with re-raise exceptions in wrapped functions.

### DIFF
--- a/lib/cli/app.py
+++ b/lib/cli/app.py
@@ -240,6 +240,9 @@ class Application(object):
         try:
             returned = self.main(*args)
         except Exception, e:
+        	elif isinstance(e, self.reraise):
+        	    # raising the last exception preserves traceback
+        	    raise
             returned = e
 
         return self.post_run(returned)


### PR DESCRIPTION
Exceptions raised in wrapped function don't re-raise properly because there is a scope change; this change forces the re-raise to be in the original scope.